### PR TITLE
fix: Remove Comic Sans from Kids branding and enlarge logos

### DIFF
--- a/src/components/HeroScrolling.astro
+++ b/src/components/HeroScrolling.astro
@@ -404,7 +404,6 @@
     .kids-active #brand-tagline {
         color: #FFD53E !important;
         font-weight: 700;
-        font-family: 'Comic Sans MS', 'Comic Sans', cursive;
         text-shadow: 3px 3px 0 #8B5A9C,
                      6px 6px 0 rgba(139, 90, 156, 0.5),
                      0 0 20px rgba(0, 0, 0, 0.3);

--- a/src/pages/events/kids-ai-vibecoding-hackathon.astro
+++ b/src/pages/events/kids-ai-vibecoding-hackathon.astro
@@ -34,12 +34,12 @@ import Layout from '../../layouts/Layout.astro';
         </div>
 
         <!-- Title -->
-        <h1 class="text-4xl md:text-6xl font-bold leading-tight" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E; -webkit-text-stroke: 2px #8B5A9C; text-shadow: 3px 3px 0 #8B5A9C;">
+        <h1 class="text-4xl md:text-6xl font-bold leading-tight" style="color: #FFD53E; -webkit-text-stroke: 2px #8B5A9C; text-shadow: 3px 3px 0 #8B5A9C;">
           Kids AI Vibecoding Hackathon
         </h1>
 
         <!-- Date and Location -->
-        <p class="text-xl md:text-2xl font-semibold" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E;">
+        <p class="text-xl md:text-2xl font-semibold" style="color: #FFD53E;">
           Saturday, October 11, 2025<br />
           Ghent • Antwerp • Brussels
         </p>

--- a/src/pages/index-new.astro
+++ b/src/pages/index-new.astro
@@ -86,16 +86,16 @@ const socialLinks = [
     <section id="ns-kids" class="min-h-screen flex flex-col items-center justify-center kids-section relative overflow-hidden px-4">
         <!-- Logo Center Stage -->
         <div class="flex justify-center mb-8 md:mb-12">
-            <img src="/nskids.png" alt="NS Kids" class="w-80 h-80 md:w-[32rem] md:h-[32rem] object-contain drop-shadow-2xl animate-float" />
+            <img src="/nskids.png" alt="NS Kids" class="w-96 h-96 md:w-[40rem] md:h-[40rem] object-contain drop-shadow-2xl animate-float" />
         </div>
 
         <!-- Title -->
-        <h2 class="text-6xl md:text-8xl font-bold mb-6 kids-title text-center" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E; text-shadow: 3px 3px 0 #8B5A9C, 6px 6px 0 rgba(139, 90, 156, 0.5); -webkit-text-stroke: 3px #8B5A9C;">
+        <h2 class="text-6xl md:text-8xl font-bold mb-6 kids-title text-center" style="color: #FFD53E; text-shadow: 3px 3px 0 #8B5A9C, 6px 6px 0 rgba(139, 90, 156, 0.5); -webkit-text-stroke: 3px #8B5A9C;">
             NS KIDS
         </h2>
 
         <!-- Tagline -->
-        <p class="text-2xl md:text-4xl font-medium mb-12 text-center" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E;">
+        <p class="text-2xl md:text-4xl font-medium mb-12 text-center" style="color: #FFD53E;">
             UNITED FOR KIDS
         </p>
 
@@ -105,11 +105,11 @@ const socialLinks = [
             <div id="kids-hackathon" class="kids-card group">
                 <div class="flex items-center gap-4 mb-4">
                     <div class="w-12 h-12 flex items-center justify-center text-3xl">🎮</div>
-                    <h3 class="text-3xl md:text-4xl font-bold" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E;">
+                    <h3 class="text-3xl md:text-4xl font-bold" style="color: #FFD53E;">
                         Hackathon
                     </h3>
                 </div>
-                <p class="text-lg md:text-xl" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E;">
+                <p class="text-lg md:text-xl" style="color: #FFD53E;">
                     Empowering young minds through creative coding and AI experiences.
                 </p>
             </div>
@@ -118,11 +118,11 @@ const socialLinks = [
             <div id="kids-mission" class="kids-card group">
                 <div class="flex items-center gap-4 mb-4">
                     <div class="w-12 h-12 flex items-center justify-center text-3xl">🎯</div>
-                    <h3 class="text-3xl md:text-4xl font-bold" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E;">
+                    <h3 class="text-3xl md:text-4xl font-bold" style="color: #FFD53E;">
                         Mission
                     </h3>
                 </div>
-                <p class="text-lg md:text-xl" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E;">
+                <p class="text-lg md:text-xl" style="color: #FFD53E;">
                     Making AI and technology accessible to kids aged 9-13 across Belgium.
                 </p>
             </div>
@@ -130,7 +130,7 @@ const socialLinks = [
 
         <!-- Sponsors Section -->
         <div class="text-center mb-6">
-            <p class="text-xl md:text-2xl font-medium mb-6" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E;">
+            <p class="text-xl md:text-2xl font-medium mb-6" style="color: #FFD53E;">
                 Our Amazing Partners
             </p>
             <div class="flex flex-wrap justify-center gap-6 items-center max-w-4xl">
@@ -152,7 +152,7 @@ const socialLinks = [
 
         <!-- Belgium Flag or Region Indicator -->
         <div class="mt-8">
-            <p class="text-lg md:text-xl font-medium" style="font-family: 'Comic Sans MS', 'Comic Sans', cursive; color: #FFD53E;">
+            <p class="text-lg md:text-xl font-medium" style="color: #FFD53E;">
                 🇧🇪 Across Belgium
             </p>
         </div>
@@ -169,7 +169,7 @@ const socialLinks = [
     <section id="ns-robotics" class="min-h-screen flex flex-col items-center justify-center robotics-section relative overflow-hidden px-4">
         <!-- Logo Center Stage -->
         <div class="flex justify-center mb-8 md:mb-12">
-            <img src="/nsrobotics-orange.png" alt="NS Robotics" class="w-80 h-80 md:w-[32rem] md:h-[32rem] object-contain drop-shadow-2xl animate-pulse-glow" />
+            <img src="/nsrobotics-orange.png" alt="NS Robotics" class="w-96 h-96 md:w-[40rem] md:h-[40rem] object-contain drop-shadow-2xl animate-pulse-glow" />
         </div>
 
         <!-- Title -->


### PR DESCRIPTION
## Summary
Removes Comic Sans font from Kids branding and makes logos larger on the index page.

## Changes
- ❌ **Remove Comic Sans** from all Kids text elements:
  - Hero component tagline
  - Index-new page (title, tagline, cards, partners)
  - Kids AI event page
- 📐 **Enlarge logos** on index-new page:
  - Mobile: `w-80` → `w-96` (20% larger)
  - Desktop: `w-[32rem]` → `w-[40rem]` (25% larger)
- ✨ Apply to both NS Kids and NS Robotics logos
- 🎨 Use default system font for cleaner, more professional look

The gold text with purple borders remains, just with a better font! 💛💜

🤖 Generated with [Claude Code](https://claude.com/claude-code)